### PR TITLE
Validate uploads with ffprobe before transcription

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@ import os
 import tempfile
 from pathlib import Path
 import logging
+import subprocess
 
 import streamlit as st
 import openai
@@ -41,38 +42,62 @@ if "transcripts" not in st.session_state:
 
 uploaded = st.file_uploader("Upload audio/video/text", type=["mp4","mp3","wav","m4a","ogg","flac","txt"], accept_multiple_files=False)
 
+
+def validate_media_file(path: str) -> bool:
+    """Run ffprobe to verify the file is a readable media container."""
+    try:
+        result = subprocess.run(
+            [
+                "ffprobe",
+                "-v",
+                "error",
+                "-show_entries",
+                "format=format_name",
+                "-of",
+                "default=noprint_wrappers=1:nokey=1",
+                path,
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            logger.error("ffprobe failed for %s: %s", path, result.stderr.strip())
+            return False
+    except Exception:
+        logger.exception("ffprobe invocation failed for %s", path)
+        return False
+    return True
+
+
+def process_uploaded_file(uploaded_file):
+    if uploaded_file.name.lower().endswith(".txt"):
+        return uploaded_file.read().decode("utf-8")
+
+    suffix = Path(uploaded_file.name).suffix
+    with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
+        tmp.write(uploaded_file.read())
+        tmp_path = tmp.name
+
+    try:
+        if not validate_media_file(tmp_path):
+            st.error("Invalid or corrupted media file")
+            return None
+        result = model.transcribe(tmp_path)
+        return result["text"]
+    finally:
+        os.unlink(tmp_path)
+
+
 if uploaded is not None:
     try:
         with st.spinner("Processing file..."):
-            if uploaded.name.lower().endswith(".txt"):
-                text = uploaded.read().decode("utf-8")
-            else:
-                suffix = Path(uploaded.name).suffix
-                with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
-                    tmp.write(uploaded.read())
-                    tmp_path = tmp.name
-                result = model.transcribe(tmp_path)
-                os.unlink(tmp_path)
-                text = result["text"]
-            st.session_state.transcripts[uploaded.name] = text
-        st.success("File processed")
+            text = process_uploaded_file(uploaded)
+            if text is not None:
+                st.session_state.transcripts[uploaded.name] = text
+                st.success("File processed")
     except Exception:
         logger.exception("Failed to process uploaded file")
         st.error("Error processing file")
-
-    with st.spinner("Processing file..."):
-        if uploaded.name.lower().endswith(".txt"):
-            text = uploaded.read().decode("utf-8")
-        else:
-            suffix = Path(uploaded.name).suffix
-            with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
-                tmp.write(uploaded.read())
-                tmp_path = tmp.name
-            result = model.transcribe(tmp_path)
-            os.unlink(tmp_path)
-            text = result["text"]
-        st.session_state.transcripts[uploaded.name] = text
-    st.success("File processed")
 
 
 st.sidebar.header("Uploaded files")

--- a/tests/test_corrupted_upload.py
+++ b/tests/test_corrupted_upload.py
@@ -1,0 +1,40 @@
+import io
+import importlib
+import logging
+import sys
+from pathlib import Path
+
+import whisper
+import torch
+
+
+class DummyUploadedFile(io.BytesIO):
+    def __init__(self, data: bytes, name: str):
+        super().__init__(data)
+        self.name = name
+
+
+def test_corrupted_upload_logs_error(monkeypatch, caplog):
+    def fake_load_model(name):
+        class DummyModel:
+            def transcribe(self, path):
+                raise AssertionError("transcribe should not be called")
+        return DummyModel()
+
+    monkeypatch.setattr(whisper, "load_model", fake_load_model)
+    monkeypatch.setattr(torch, "compile", lambda model, mode=None: model)
+
+    sys.path.append(str(Path(__file__).resolve().parent.parent))
+    app = importlib.import_module("app")
+
+    error_called = {}
+    monkeypatch.setattr(app.st, "error", lambda msg: error_called.setdefault("msg", msg))
+
+    caplog.set_level(logging.ERROR)
+
+    uploaded = DummyUploadedFile(b"not a real media file", "bad.mp3")
+    text = app.process_uploaded_file(uploaded)
+
+    assert text is None
+    assert error_called.get("msg") == "Invalid or corrupted media file"
+    assert any("ffprobe" in record.message for record in caplog.records)


### PR DESCRIPTION
## Summary
- validate uploaded media with ffprobe before transcription
- show an error and skip transcription when ffprobe fails
- add regression test for corrupted media uploads

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1d67c023c832fa1999c9974f9bce9