### PR TITLE
Validate uploads with ffprobe before transcription

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,9 +2,10 @@ import os
 import tempfile
 from pathlib import Path
 import logging
+import subprocess
 
 import streamlit as st
-import openai
+from openai import OpenAI
 import whisper
 import torch
 
@@ -39,40 +40,76 @@ st.title("Transcriber")
 if "transcripts" not in st.session_state:
     st.session_state["transcripts"] = {}
 
-uploaded = st.file_uploader("Upload audio/video/text", type=["mp4","mp3","wav","m4a","ogg","flac","txt"], accept_multiple_files=False)
+uploaded = st.file_uploader(
+    "Upload audio/video/text",
+    type=["mp4", "mp3", "wav", "m4a", "ogg", "flac", "txt"],
+    accept_multiple_files=False,
+    key="uploader",
+)
 
-if uploaded is not None:
+
+def validate_media_file(path: str) -> bool:
+    """Run ffprobe to verify the file is a readable media container."""
+    try:
+        result = subprocess.run(
+            [
+                "ffprobe",
+                "-v",
+                "error",
+                "-show_entries",
+                "format=format_name",
+                "-of",
+                "default=noprint_wrappers=1:nokey=1",
+                path,
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            logger.error("ffprobe failed for %s: %s", path, result.stderr.strip())
+            return False
+    except Exception:
+        logger.exception("ffprobe invocation failed for %s", path)
+        return False
+    return True
+
+
+def process_uploaded_file(uploaded_file):
+    if uploaded_file.name.lower().endswith(".txt"):
+        return uploaded_file.read().decode("utf-8")
+
+    suffix = Path(uploaded_file.name).suffix
+    with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
+        tmp.write(uploaded_file.read())
+        tmp_path = tmp.name
+
+    try:
+        if not validate_media_file(tmp_path):
+            st.error("Invalid or corrupted media file")
+            return None
+        result = model.transcribe(tmp_path)
+        return result["text"]
+    finally:
+        os.unlink(tmp_path)
+
+
+def handle_new_upload(uploaded_file):
+    if uploaded_file is None or uploaded_file.name in st.session_state.transcripts:
+        return
     try:
         with st.spinner("Processing file..."):
-            if uploaded.name.lower().endswith(".txt"):
-                text = uploaded.read().decode("utf-8")
-            else:
-                suffix = Path(uploaded.name).suffix
-                with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
-                    tmp.write(uploaded.read())
-                    tmp_path = tmp.name
-                result = model.transcribe(tmp_path)
-                os.unlink(tmp_path)
-                text = result["text"]
-            st.session_state.transcripts[uploaded.name] = text
-        st.success("File processed")
+            text = process_uploaded_file(uploaded_file)
+            if text is not None:
+                st.session_state.transcripts[uploaded_file.name] = text
+                st.success("File processed")
     except Exception:
         logger.exception("Failed to process uploaded file")
         st.error("Error processing file")
+    finally:
+        st.session_state.uploader = None
 
-    with st.spinner("Processing file..."):
-        if uploaded.name.lower().endswith(".txt"):
-            text = uploaded.read().decode("utf-8")
-        else:
-            suffix = Path(uploaded.name).suffix
-            with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
-                tmp.write(uploaded.read())
-                tmp_path = tmp.name
-            result = model.transcribe(tmp_path)
-            os.unlink(tmp_path)
-            text = result["text"]
-        st.session_state.transcripts[uploaded.name] = text
-    st.success("File processed")
+
+handle_new_upload(uploaded)
 
 
 st.sidebar.header("Uploaded files")
@@ -94,8 +131,8 @@ if st.sidebar.button("Execute") and selected:
     ]
 
     try:
-        openai.api_base = centgpt_url
-        response = openai.ChatCompletion.create(
+        client = OpenAI(base_url=centgpt_url)
+        response = client.chat.completions.create(
             model="llama3-70b-instruct",
             messages=messages,
             stream=True,
@@ -103,26 +140,12 @@ if st.sidebar.button("Execute") and selected:
         placeholder = st.empty()
         collected = ""
         for chunk in response:
-            delta = chunk["choices"][0].get("delta", {})
-            if delta.get("content"):
-                collected += delta["content"]
+            delta = chunk.choices[0].delta.content
+            if delta:
+                collected += delta
                 placeholder.markdown(collected)
     except Exception:
         logger.exception("LLM request failed")
         st.error("Error contacting language model")
-
-    openai.api_base = centgpt_url
-    response = openai.ChatCompletion.create(
-        model="llama3-70b-instruct",
-        messages=messages,
-        stream=True,
-    )
-    placeholder = st.empty()
-    collected = ""
-    for chunk in response:
-        delta = chunk["choices"][0].get("delta", {})
-        if delta.get("content"):
-            collected += delta["content"]
-            placeholder.markdown(collected)
 
 

--- a/tests/test_corrupted_upload.py
+++ b/tests/test_corrupted_upload.py
@@ -1,0 +1,40 @@
+import io
+import importlib
+import logging
+import sys
+from pathlib import Path
+
+import whisper
+import torch
+
+
+class DummyUploadedFile(io.BytesIO):
+    def __init__(self, data: bytes, name: str):
+        super().__init__(data)
+        self.name = name
+
+
+def test_corrupted_upload_logs_error(monkeypatch, caplog):
+    def fake_load_model(name):
+        class DummyModel:
+            def transcribe(self, path):
+                raise AssertionError("transcribe should not be called")
+        return DummyModel()
+
+    monkeypatch.setattr(whisper, "load_model", fake_load_model)
+    monkeypatch.setattr(torch, "compile", lambda model, mode=None: model)
+
+    sys.path.append(str(Path(__file__).resolve().parent.parent))
+    app = importlib.import_module("app")
+
+    error_called = {}
+    monkeypatch.setattr(app.st, "error", lambda msg: error_called.setdefault("msg", msg))
+
+    caplog.set_level(logging.ERROR)
+
+    uploaded = DummyUploadedFile(b"not a real media file", "bad.mp3")
+    text = app.process_uploaded_file(uploaded)
+
+    assert text is None
+    assert error_called.get("msg") == "Invalid or corrupted media file"
+    assert any("ffprobe" in record.message for record in caplog.records)

--- a/tests/test_no_reprocess.py
+++ b/tests/test_no_reprocess.py
@@ -1,0 +1,47 @@
+import io
+import importlib
+import sys
+from pathlib import Path
+import contextlib
+
+import whisper
+import torch
+
+
+class DummyUploadedFile(io.BytesIO):
+    def __init__(self, data: bytes, name: str):
+        super().__init__(data)
+        self.name = name
+
+
+def test_no_reprocess_on_rerun(monkeypatch):
+    class DummyModel:
+        def transcribe(self, path):
+            return {"text": "dummy"}
+
+    monkeypatch.setattr(whisper, "load_model", lambda name: DummyModel())
+    monkeypatch.setattr(torch, "compile", lambda model, mode=None: model)
+
+    sys.path.append(str(Path(__file__).resolve().parent.parent))
+    app = importlib.import_module("app")
+
+    app.st.session_state.clear()
+    app.st.session_state["transcripts"] = {}
+
+    calls = {"n": 0}
+
+    def fake_process(file):
+        calls["n"] += 1
+        return "ok"
+
+    monkeypatch.setattr(app, "process_uploaded_file", fake_process)
+    monkeypatch.setattr(app.st, "spinner", lambda *a, **k: contextlib.nullcontext())
+    monkeypatch.setattr(app.st, "success", lambda msg: None)
+    monkeypatch.setattr(app.st, "error", lambda msg: None)
+
+    uploaded = DummyUploadedFile(b"data", "good.mp3")
+
+    app.handle_new_upload(uploaded)
+    app.handle_new_upload(uploaded)
+
+    assert calls["n"] == 1


### PR DESCRIPTION
## Summary
- validate uploaded media with ffprobe before transcription
- show an error and skip transcription when ffprobe fails
- prevent processed files from re-uploading when using sidebar controls
- add regression tests for corrupted and repeated uploads
- migrate to new OpenAI client API for streaming LLM responses

## Testing
- `python -m py_compile app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1d67c023c832fa1999c9974f9bce9