### PR TITLE
Enable CUDA-based transcription with progress feedback

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-FROM python:3.10-slim
+FROM pytorch/pytorch:2.1.0-cuda12.8-cudnn8-runtime
 
+# Install ffmpeg for media processing
 RUN apt-get update && apt-get install -y ffmpeg && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/app.py
+++ b/app.py
@@ -2,11 +2,13 @@ import os
 import tempfile
 from pathlib import Path
 import logging
+import subprocess
 
 import streamlit as st
-import openai
+from openai import OpenAI
 import whisper
 import torch
+import tqdm
 
 logging.basicConfig(
     format="%(asctime)s %(levelname)s: %(message)s",
@@ -23,13 +25,18 @@ GEM_PROMPT = "<GEM_PROMPT_PLACEHOLDER>"
 @st.cache_resource
 def load_model():
     try:
-        model = whisper.load_model("large-v3")
-        return torch.compile(model, mode="reduce-overhead")
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+        logger.info("Loading Whisper model on %s", device)
+        try:
+            model = whisper.load_model("large-v3", device=device)
+        except TypeError:
+            model = whisper.load_model("large-v3")
+        if device == "cuda":
+            model = torch.compile(model, mode="reduce-overhead")
+        return model
     except Exception:
         logger.exception("Failed to load Whisper model")
         raise
-
-    return whisper.load_model("large-v3")
 
 
 model = load_model()
@@ -39,40 +46,98 @@ st.title("Transcriber")
 if "transcripts" not in st.session_state:
     st.session_state["transcripts"] = {}
 
-uploaded = st.file_uploader("Upload audio/video/text", type=["mp4","mp3","wav","m4a","ogg","flac","txt"], accept_multiple_files=False)
+uploaded = st.file_uploader(
+    "Upload audio/video/text",
+    type=["mp4", "mp3", "wav", "m4a", "ogg", "flac", "txt"],
+    accept_multiple_files=False,
+    key="uploader",
+)
 
-if uploaded is not None:
+
+def validate_media_file(path: str) -> bool:
+    """Run ffprobe to verify the file is a readable media container."""
+    try:
+        result = subprocess.run(
+            [
+                "ffprobe",
+                "-v",
+                "error",
+                "-show_entries",
+                "format=format_name",
+                "-of",
+                "default=noprint_wrappers=1:nokey=1",
+                path,
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            logger.error("ffprobe failed for %s: %s", path, result.stderr.strip())
+            return False
+    except Exception:
+        logger.exception("ffprobe invocation failed for %s", path)
+        return False
+    return True
+
+
+def process_uploaded_file(uploaded_file):
+    if uploaded_file.name.lower().endswith(".txt"):
+        return uploaded_file.read().decode("utf-8")
+
+    suffix = Path(uploaded_file.name).suffix
+    with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
+        tmp.write(uploaded_file.read())
+        tmp_path = tmp.name
+
+    try:
+        if not validate_media_file(tmp_path):
+            st.error("Invalid or corrupted media file")
+            return None
+        progress_bar = st.progress(0)
+        original_tqdm = tqdm.tqdm
+
+        class StreamlitTqdm(original_tqdm):
+            def update(self, n=1):
+                super().update(n)
+                if self.total:
+                    progress = int(self.n / self.total * 100)
+                    progress_bar.progress(min(progress, 100))
+
+            def close(self):
+                progress_bar.progress(100)
+                super().close()
+
+        tqdm.tqdm = StreamlitTqdm
+        try:
+            try:
+                result = model.transcribe(tmp_path, verbose=None)
+            except TypeError:
+                result = model.transcribe(tmp_path)
+            return result["text"]
+        finally:
+            tqdm.tqdm = original_tqdm
+            progress_bar.empty()
+    finally:
+        os.unlink(tmp_path)
+
+
+def handle_new_upload(uploaded_file):
+    if uploaded_file is None or uploaded_file.name in st.session_state.transcripts:
+        return
     try:
         with st.spinner("Processing file..."):
-            if uploaded.name.lower().endswith(".txt"):
-                text = uploaded.read().decode("utf-8")
-            else:
-                suffix = Path(uploaded.name).suffix
-                with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
-                    tmp.write(uploaded.read())
-                    tmp_path = tmp.name
-                result = model.transcribe(tmp_path)
-                os.unlink(tmp_path)
-                text = result["text"]
-            st.session_state.transcripts[uploaded.name] = text
-        st.success("File processed")
+            text = process_uploaded_file(uploaded_file)
+            if text is not None:
+                st.session_state.transcripts[uploaded_file.name] = text
+                st.success("File processed")
     except Exception:
         logger.exception("Failed to process uploaded file")
         st.error("Error processing file")
+    finally:
+        st.session_state.uploader = None
 
-    with st.spinner("Processing file..."):
-        if uploaded.name.lower().endswith(".txt"):
-            text = uploaded.read().decode("utf-8")
-        else:
-            suffix = Path(uploaded.name).suffix
-            with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
-                tmp.write(uploaded.read())
-                tmp_path = tmp.name
-            result = model.transcribe(tmp_path)
-            os.unlink(tmp_path)
-            text = result["text"]
-        st.session_state.transcripts[uploaded.name] = text
-    st.success("File processed")
+
+handle_new_upload(uploaded)
 
 
 st.sidebar.header("Uploaded files")
@@ -94,8 +159,8 @@ if st.sidebar.button("Execute") and selected:
     ]
 
     try:
-        openai.api_base = centgpt_url
-        response = openai.ChatCompletion.create(
+        client = OpenAI(base_url=centgpt_url)
+        response = client.chat.completions.create(
             model="llama3-70b-instruct",
             messages=messages,
             stream=True,
@@ -103,26 +168,12 @@ if st.sidebar.button("Execute") and selected:
         placeholder = st.empty()
         collected = ""
         for chunk in response:
-            delta = chunk["choices"][0].get("delta", {})
-            if delta.get("content"):
-                collected += delta["content"]
+            delta = chunk.choices[0].delta.content
+            if delta:
+                collected += delta
                 placeholder.markdown(collected)
     except Exception:
         logger.exception("LLM request failed")
         st.error("Error contacting language model")
-
-    openai.api_base = centgpt_url
-    response = openai.ChatCompletion.create(
-        model="llama3-70b-instruct",
-        messages=messages,
-        stream=True,
-    )
-    placeholder = st.empty()
-    collected = ""
-    for chunk in response:
-        delta = chunk["choices"][0].get("delta", {})
-        if delta.get("content"):
-            collected += delta["content"]
-            placeholder.markdown(collected)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,4 @@ openai
 ffmpeg-python
 openai-whisper
 faster-whisper
-torch
 

--- a/tests/test_corrupted_upload.py
+++ b/tests/test_corrupted_upload.py
@@ -1,0 +1,40 @@
+import io
+import importlib
+import logging
+import sys
+from pathlib import Path
+
+import whisper
+import torch
+
+
+class DummyUploadedFile(io.BytesIO):
+    def __init__(self, data: bytes, name: str):
+        super().__init__(data)
+        self.name = name
+
+
+def test_corrupted_upload_logs_error(monkeypatch, caplog):
+    def fake_load_model(name):
+        class DummyModel:
+            def transcribe(self, path):
+                raise AssertionError("transcribe should not be called")
+        return DummyModel()
+
+    monkeypatch.setattr(whisper, "load_model", fake_load_model)
+    monkeypatch.setattr(torch, "compile", lambda model, mode=None: model)
+
+    sys.path.append(str(Path(__file__).resolve().parent.parent))
+    app = importlib.import_module("app")
+
+    error_called = {}
+    monkeypatch.setattr(app.st, "error", lambda msg: error_called.setdefault("msg", msg))
+
+    caplog.set_level(logging.ERROR)
+
+    uploaded = DummyUploadedFile(b"not a real media file", "bad.mp3")
+    text = app.process_uploaded_file(uploaded)
+
+    assert text is None
+    assert error_called.get("msg") == "Invalid or corrupted media file"
+    assert any("ffprobe" in record.message for record in caplog.records)

--- a/tests/test_no_reprocess.py
+++ b/tests/test_no_reprocess.py
@@ -1,0 +1,47 @@
+import io
+import importlib
+import sys
+from pathlib import Path
+import contextlib
+
+import whisper
+import torch
+
+
+class DummyUploadedFile(io.BytesIO):
+    def __init__(self, data: bytes, name: str):
+        super().__init__(data)
+        self.name = name
+
+
+def test_no_reprocess_on_rerun(monkeypatch):
+    class DummyModel:
+        def transcribe(self, path):
+            return {"text": "dummy"}
+
+    monkeypatch.setattr(whisper, "load_model", lambda name: DummyModel())
+    monkeypatch.setattr(torch, "compile", lambda model, mode=None: model)
+
+    sys.path.append(str(Path(__file__).resolve().parent.parent))
+    app = importlib.import_module("app")
+
+    app.st.session_state.clear()
+    app.st.session_state["transcripts"] = {}
+
+    calls = {"n": 0}
+
+    def fake_process(file):
+        calls["n"] += 1
+        return "ok"
+
+    monkeypatch.setattr(app, "process_uploaded_file", fake_process)
+    monkeypatch.setattr(app.st, "spinner", lambda *a, **k: contextlib.nullcontext())
+    monkeypatch.setattr(app.st, "success", lambda msg: None)
+    monkeypatch.setattr(app.st, "error", lambda msg: None)
+
+    uploaded = DummyUploadedFile(b"data", "good.mp3")
+
+    app.handle_new_upload(uploaded)
+    app.handle_new_upload(uploaded)
+
+    assert calls["n"] == 1

--- a/tests/test_progress_bar.py
+++ b/tests/test_progress_bar.py
@@ -1,0 +1,48 @@
+import io
+import importlib
+import sys
+from pathlib import Path
+
+
+class DummyUploadedFile(io.BytesIO):
+    def __init__(self, data: bytes, name: str):
+        super().__init__(data)
+        self.name = name
+
+
+def test_progress_bar_invoked(monkeypatch):
+    sys.path.append(str(Path(__file__).resolve().parent.parent))
+    app = importlib.import_module("app")
+
+    class DummyModel:
+        def transcribe(self, path, verbose=None):
+            from tqdm import tqdm
+            for _ in tqdm(range(2)):
+                pass
+            return {"text": "ok"}
+
+    called = {"progress": 0}
+
+    def fake_progress(val):
+        called["progress"] += 1
+
+        class PB:
+            def progress(self, v):
+                called["progress"] += 1
+
+            def empty(self):
+                pass
+
+        return PB()
+
+    monkeypatch.setattr(app, "model", DummyModel())
+    monkeypatch.setattr(app.st, "progress", fake_progress)
+    monkeypatch.setattr(app.st, "error", lambda msg: None)
+    monkeypatch.setattr(app, "validate_media_file", lambda p: True)
+
+    uploaded = DummyUploadedFile(b"data", "good.mp3")
+    text = app.process_uploaded_file(uploaded)
+
+    assert text == "ok"
+    assert called["progress"] > 1
+


### PR DESCRIPTION
## Summary
- Run container on CUDA 12.8 PyTorch runtime with ffmpeg
- Load Whisper on GPU when available and display transcription progress bar
- Validate uploads with ffprobe and skip transcription on invalid files
- Avoid reprocessing of already uploaded files

## Testing
- `python -m py_compile app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1d67c023c832fa1999c9974f9bce9